### PR TITLE
Fix comment in setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -10,7 +10,7 @@ end
 
 FileUtils.chdir APP_ROOT do
   # This script is a way to setup or update your development environment automatically.
-  # This script is idempotent, so that you can run it at anytime and get an expectable outcome.
+  # This script is idempotent, so that you can run it at anytime and get an expected outcome.
   # Add necessary setup steps to this file.
 
   puts '== Installing dependencies =='


### PR DESCRIPTION
## Summary
- fix typo in `bin/setup` comment

## Testing
- `ruby -c bin/setup` *(fails: ruby not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6883b6f9a678832c875e41ec20dd851a