### PR TITLE
Add JSON API setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,30 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## Running the mock JSON API
+
+This project includes a `db.json` file with sample data. You can serve this
+file using [json-server](https://github.com/typicode/json-server):
+
+```bash
+# Install json-server globally if you don't have it
+npm install -g json-server
+
+# Start the API on http://localhost:3000
+json-server --watch db.json
+```
+
+The Rails application expects the API to be available at `localhost:3000`.
+
+## Accessing the Rails app
+
+Once the mock API is running, start the Rails server on another port to avoid a
+conflict:
+
+```bash
+rails server -p 3001
+```
+
+Open [http://localhost:3001](http://localhost:3001) in your browser to interact
+with the application.


### PR DESCRIPTION
## Summary
- document how to start json-server with `db.json`
- mention running Rails on a different port and where to view it

## Testing
- `bundle exec rake -T` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883b71299ec832c81da0d47c3cfe5b6