### PR TITLE
Fix album destroy scoping

### DIFF
--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -16,7 +16,9 @@ class AlbumsController < ApplicationController
   private
 
   def set_album
-    @album = Album.find(params[:id])
+    @album = @user.albums.find(params[:id])
+  rescue ActiveResource::ResourceNotFound
+    redirect_to user_albums_path(@user), notice: 'Album not found.'
   end
 
   def set_user

--- a/test/controllers/albums_controller_test.rb
+++ b/test/controllers/albums_controller_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class AlbumsControllerTest < ActionDispatch::IntegrationTest
+  test "redirect when album not found" do
+    user = User.new(id: 1)
+    User.stub :find, user do
+      stub_albums = Minitest::Mock.new
+      stub_albums.expect :find, -> { raise ActiveResource::ResourceNotFound.new(nil) }, ['99']
+      user.stub :albums, stub_albums do
+        delete user_album_url(user, id: '99')
+        assert_redirected_to user_albums_path(user)
+        assert_equal 'Album not found.', flash[:notice]
+      end
+      stub_albums.verify
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,7 @@
+ENV['RAILS_ENV'] ||= 'test'
+require_relative '../config/environment'
+require 'rails/test_help'
+
+class ActiveSupport::TestCase
+  parallelize(workers: :number_of_processors)
+end


### PR DESCRIPTION
## Summary
- ensure album deletion happens under the current user
- handle missing albums with a redirect
- add controller test skeleton

## Testing
- `bin/rails test` *(fails: `ruby` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883b708059c832cbe71644126875710